### PR TITLE
Generate an includes file to make troubleshooting easier.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+/nbproject/private/
+/nbproject/


### PR DESCRIPTION
An includes.txt file is now generated, listing all of the files that were included in the client library. Additionally, the code was cleaned up:

1. Calls to grunt.file.write were updated to use a method to reduce repetition.
2. The logic to retrieve a client library configuration from the Gruntfile options was put in its own method for reusability.